### PR TITLE
fix: Installed pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,10 @@ $(COMMON_CONSTRAINTS_TXT):
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q -r requirements/pip_tools.txt
-	pip-compile --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile --allow-unsafe --upgrade --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip_tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/test.txt requirements/test.in
 	pip-compile --upgrade -o requirements/quality.txt requirements/quality.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,28 +6,27 @@
 #
 appdirs==1.4.4
     # via fs
-asgiref==3.4.1
+asgiref==3.5.2
     # via django
-django==3.2.9
+django==3.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-fs==2.4.14
+fs==2.4.16
     # via xblock
-lxml==4.6.4
+lxml==4.9.0
     # via xblock
-mako==1.1.6
+mako==1.2.0
     # via xblock-utils
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   mako
     #   xblock
 python-dateutil==2.8.2
     # via xblock
-pytz==2021.3
+pytz==2022.1
     # via
     #   django
-    #   fs
     #   xblock
 pyyaml==6.0
     # via xblock
@@ -40,17 +39,17 @@ six==1.16.0
     #   python-dateutil
 sqlparse==0.4.2
     # via django
-web-fragments==1.1.0
+web-fragments==2.0.0
     # via
     #   xblock
     #   xblock-utils
 webob==1.8.7
     # via xblock
-xblock==1.5.1
+xblock==1.6.1
     # via
     #   -r requirements/base.in
     #   xblock-utils
-xblock-utils==2.2.0
+xblock-utils==3.0.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,25 +4,21 @@
 #
 #    make upgrade
 #
-backports.entry-points-selectable==1.1.1
-    # via
-    #   -r requirements/tox.txt
-    #   virtualenv
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.12
     # via requests
-coverage==6.1.2
+coverage==6.4.1
     # via coveralls
 coveralls==3.3.1
     # via -r requirements/ci.in
-distlib==0.3.3
+distlib==0.3.4
     # via
     #   -r requirements/tox.txt
     #   virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.4.0
+filelock==3.7.1
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -33,7 +29,7 @@ packaging==21.3
     # via
     #   -r requirements/tox.txt
     #   tox
-platformdirs==2.4.0
+platformdirs==2.5.2
     # via
     #   -r requirements/tox.txt
     #   virtualenv
@@ -45,11 +41,11 @@ py==1.11.0
     # via
     #   -r requirements/tox.txt
     #   tox
-pyparsing==3.0.6
+pyparsing==3.0.9
     # via
     #   -r requirements/tox.txt
     #   packaging
-requests==2.26.0
+requests==2.28.0
     # via coveralls
 six==1.16.0
     # via
@@ -60,11 +56,11 @@ toml==0.10.2
     # via
     #   -r requirements/tox.txt
     #   tox
-tox==3.24.4
+tox==3.25.0
     # via -r requirements/tox.txt
-urllib3==1.26.7
+urllib3==1.26.9
     # via requests
-virtualenv==20.10.0
+virtualenv==20.14.1
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -13,8 +13,13 @@
 
 
 # using LTS django version
-Django<3.3
+Django<4.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0
+
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,3 +1,4 @@
+-c constraints.txt
 # Core dependencies for installing other packages
 
 pip

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,13 @@
 #
 #    make upgrade
 #
-wheel==0.36.2
+wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.3.4
+pip==22.1.2
     # via -r requirements/pip.in
-setuptools==50.3.2
-    # via -r requirements/pip.in
+setuptools==59.8.0
+    # via
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-click==8.0.3
+click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.6.2
     # via -r requirements/pip_tools.in
-tomli==1.2.2
+tomli==2.0.1
     # via pep517
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -9,38 +9,74 @@ appdirs==1.4.4
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   fs
-asgiref==3.4.1
+arrow==1.2.2
+    # via
+    #   -r requirements/test.txt
+    #   jinja2-time
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django
-astroid==2.8.6
+astroid==2.11.6
     # via pylint
-boto3==1.20.11
+binaryornot==0.4.4
+    # via
+    #   -r requirements/test.txt
+    #   cookiecutter
+boto==2.49.0
+    # via
+    #   -r requirements/test.txt
+    #   xblock-sdk
+boto3==1.24.10
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.23.11
+botocore==1.27.10
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-coverage==6.1.2
+certifi==2022.6.15
+    # via
+    #   -r requirements/test.txt
+    #   requests
+chardet==4.0.0
+    # via
+    #   -r requirements/test.txt
+    #   binaryornot
+charset-normalizer==2.0.12
+    # via
+    #   -r requirements/test.txt
+    #   requests
+click==8.1.3
+    # via
+    #   -r requirements/test.txt
+    #   cookiecutter
+cookiecutter==2.1.1
+    # via
+    #   -r requirements/test.txt
+    #   xblock-sdk
+coverage==6.4.1
     # via -r requirements/test.txt
-ddt==1.4.4
+ddt==1.5.0
     # via -r requirements/test.txt
-django==3.2.9
+dill==0.3.5.1
+    # via pylint
+django==3.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django-pyfs
     #   xblock-sdk
-django-pyfs==3.1.0
+django-pyfs==3.2.0
+    # via
+    #   -r requirements/test.txt
+    #   xblock-sdk
+edx-opaque-keys==2.3.0
     # via -r requirements/test.txt
-edx-opaque-keys==2.2.2
-    # via -r requirements/test.txt
-fs==2.4.14
+fs==2.4.16
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -51,70 +87,102 @@ fs-s3fs==1.1.1
     # via
     #   -r requirements/test.txt
     #   django-pyfs
+    #   xblock-sdk
+idna==3.3
+    # via
+    #   -r requirements/test.txt
+    #   requests
 isort==5.10.1
     # via pylint
-jmespath==0.10.0
+jinja2==3.1.2
+    # via
+    #   -r requirements/test.txt
+    #   cookiecutter
+    #   jinja2-time
+jinja2-time==0.2.0
+    # via
+    #   -r requirements/test.txt
+    #   cookiecutter
+jmespath==1.0.0
     # via
     #   -r requirements/test.txt
     #   boto3
     #   botocore
 lazy==1.4
-    # via -r requirements/test.txt
-lazy-object-proxy==1.6.0
+    # via
+    #   -r requirements/test.txt
+    #   xblock-sdk
+lazy-object-proxy==1.7.1
     # via astroid
-lxml==4.6.4
+lxml==4.9.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   xblock
-mako==1.1.6
+    #   xblock-sdk
+mako==1.2.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   xblock-utils
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
+    #   jinja2
     #   mako
     #   xblock
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via -r requirements/test.txt
-pbr==5.8.0
+pbr==5.9.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.4.0
+platformdirs==2.5.2
     # via pylint
 pycodestyle==2.8.0
     # via -r requirements/quality.in
-pylint==2.11.1
+pylint==2.14.2
     # via -r requirements/quality.in
-pymongo==3.12.1
+pymongo==3.12.3
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
+pypng==0.0.21
+    # via
+    #   -r requirements/test.txt
+    #   xblock-sdk
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
+    #   arrow
     #   botocore
     #   xblock
-pytz==2021.3
+python-slugify==6.1.2
+    # via
+    #   -r requirements/test.txt
+    #   cookiecutter
+pytz==2022.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django
-    #   fs
     #   xblock
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
+    #   cookiecutter
     #   xblock
-s3transfer==0.5.0
+requests==2.28.0
+    # via
+    #   -r requirements/test.txt
+    #   cookiecutter
+    #   xblock-sdk
+s3transfer==0.6.0
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -122,6 +190,7 @@ simplejson==3.17.6
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
+    #   xblock-sdk
     #   xblock-utils
 six==1.16.0
     # via
@@ -139,37 +208,47 @@ stevedore==3.5.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
-toml==0.10.2
+text-unidecode==1.3
+    # via
+    #   -r requirements/test.txt
+    #   python-slugify
+tomli==2.0.1
     # via pylint
-typing-extensions==4.0.0
+tomlkit==0.11.0
+    # via pylint
+typing-extensions==4.2.0
     # via
     #   astroid
     #   pylint
-urllib3==1.26.7
+urllib3==1.26.9
     # via
     #   -r requirements/test.txt
     #   botocore
-web-fragments==1.1.0
+    #   requests
+web-fragments==2.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   xblock
+    #   xblock-sdk
     #   xblock-utils
 webob==1.8.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   xblock
-wrapt==1.13.3
+    #   xblock-sdk
+wrapt==1.14.1
     # via astroid
-xblock==1.5.1
+xblock==1.6.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
+    #   xblock-sdk
     #   xblock-utils
-xblock-sdk==0.4.0
+xblock-sdk==0.5.1
     # via -r requirements/test.txt
-xblock-utils==2.2.0
+xblock-utils==3.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,68 +6,113 @@
 #
 appdirs==1.4.4
     # via fs
-asgiref==3.4.1
+arrow==1.2.2
+    # via jinja2-time
+asgiref==3.5.2
     # via django
-boto3==1.20.11
+binaryornot==0.4.4
+    # via cookiecutter
+boto==2.49.0
+    # via xblock-sdk
+boto3==1.24.10
     # via fs-s3fs
-botocore==1.23.11
+botocore==1.27.10
     # via
     #   boto3
     #   s3transfer
-coverage==6.1.2
+certifi==2022.6.15
+    # via requests
+chardet==4.0.0
+    # via binaryornot
+charset-normalizer==2.0.12
+    # via requests
+click==8.1.3
+    # via cookiecutter
+cookiecutter==2.1.1
+    # via xblock-sdk
+coverage==6.4.1
     # via -r requirements/test.in
-ddt==1.4.4
+ddt==1.5.0
     # via -r requirements/test.in
     # via
     #   -c requirements/common_constraints.txt
     #   django-pyfs
     #   xblock-sdk
-django-pyfs==3.1.0
+django-pyfs==3.2.0
+    # via
+    #   -r requirements/test.in
+    #   xblock-sdk
+edx-opaque-keys==2.3.0
     # via -r requirements/test.in
-edx-opaque-keys==2.2.2
-    # via -r requirements/test.in
-fs==2.4.14
+fs==2.4.16
     # via
     #   django-pyfs
     #   fs-s3fs
     #   xblock
 fs-s3fs==1.1.1
-    # via django-pyfs
-jmespath==0.10.0
+    # via
+    #   django-pyfs
+    #   xblock-sdk
+idna==3.3
+    # via requests
+jinja2==3.1.2
+    # via
+    #   cookiecutter
+    #   jinja2-time
+jinja2-time==0.2.0
+    # via cookiecutter
+jmespath==1.0.0
     # via
     #   boto3
     #   botocore
 lazy==1.4
-    # via -r requirements/test.in
-lxml==4.6.4
-    # via xblock
-mako==1.1.6
-    # via xblock-utils
-markupsafe==2.0.1
     # via
+    #   -r requirements/test.in
+    #   xblock-sdk
+lxml==4.9.0
+    # via
+    #   xblock
+    #   xblock-sdk
+mako==1.2.0
+    # via xblock-utils
+markupsafe==2.1.1
+    # via
+    #   jinja2
     #   mako
     #   xblock
 mock==4.0.3
     # via -r requirements/test.in
-pbr==5.8.0
+pbr==5.9.0
     # via stevedore
-pymongo==3.12.1
+pymongo==3.12.3
     # via edx-opaque-keys
+pypng==0.0.21
+    # via xblock-sdk
 python-dateutil==2.8.2
     # via
+    #   arrow
     #   botocore
     #   xblock
-pytz==2021.3
+python-slugify==6.1.2
+    # via cookiecutter
+pytz==2022.1
     # via
     #   django
-    #   fs
     #   xblock
 pyyaml==6.0
-    # via xblock
-s3transfer==0.5.0
+    # via
+    #   cookiecutter
+    #   xblock
+requests==2.28.0
+    # via
+    #   cookiecutter
+    #   xblock-sdk
+s3transfer==0.6.0
     # via boto3
 simplejson==3.17.6
-    # via xblock-utils
+    # via
+    #   xblock-sdk
+    #   xblock-utils
 six==1.16.0
     # via
     #   fs
@@ -77,19 +122,28 @@ sqlparse==0.4.2
     # via django
 stevedore==3.5.0
     # via edx-opaque-keys
-urllib3==1.26.7
-    # via botocore
-web-fragments==1.1.0
+text-unidecode==1.3
+    # via python-slugify
+urllib3==1.26.9
+    # via
+    #   botocore
+    #   requests
+web-fragments==2.0.0
     # via
     #   xblock
+    #   xblock-sdk
     #   xblock-utils
 webob==1.8.7
-    # via xblock
-xblock==1.5.1
-    # via xblock-utils
-xblock-sdk==0.4.0
+    # via
+    #   xblock
+    #   xblock-sdk
+xblock==1.6.1
+    # via
+    #   xblock-sdk
+    #   xblock-utils
+xblock-sdk==0.5.1
     # via -r requirements/test.in
-xblock-utils==2.2.0
+xblock-utils==3.0.0
     # via -r requirements/test.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,23 +4,21 @@
 #
 #    make upgrade
 #
-backports.entry-points-selectable==1.1.1
+distlib==0.3.4
     # via virtualenv
-distlib==0.3.3
-    # via virtualenv
-filelock==3.4.0
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv
 packaging==21.3
     # via tox
-platformdirs==2.4.0
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.6
+pyparsing==3.0.9
     # via packaging
 six==1.16.0
     # via
@@ -28,7 +26,7 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.24.4
+tox==3.25.0
     # via -r requirements/tox.in
-virtualenv==20.10.0
+virtualenv==20.14.1
     # via tox


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.

JIRA: https://2u-internal.atlassian.net/browse/BOM-3453