### PR TITLE
fix!: drop support for Django<3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,12 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: ['3.8']
-        toxenv: [django22, django30, django31, django32, quality,
-                 csslint, eslint, translations_validate]
+        toxenv: [django32, quality, csslint, eslint, translations_validate]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 3.0.0
+* Removed Support for Django 2.2, 3.0 and 3.1
+
 ## Version 2.1.0
 * Added support for Django 3.0, 3.1 and 3.2
 

--- a/freetextresponse/__init__.py
+++ b/freetextresponse/__init__.py
@@ -3,3 +3,5 @@ This is an XBlock that accepts a free-text response from students.
 Instructors can specify a list of phrases, of which one must be
 present in order for the student to receive credit.
 """
+
+__version__ = "3.0.0"

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,23 @@ from os import path, walk
 
 from setuptools import setup
 
-version = '2.1.1'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:
     long_description = file_in.read()
+
+
+def get_version(*file_paths):
+    """
+    Extract the version string from the file at the given relative path fragments.
+    """
+    filename = os.path.join(os.path.dirname(__file__), *file_paths)
+    version_file = open(filename, encoding="utf8").read()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError('Unable to find version string.')
 
 
 def package_data(pkg, roots):
@@ -94,10 +106,11 @@ def is_requirement(line):
 
     return line and line.strip() and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
 
+VERSION = get_version('freetextresponse', '__init__.py')
 
 setup(
     name='xblock-free-text-response',
-    version=version,
+    version=VERSION,
     description=description,
     long_description=long_description,
     author='stv',
@@ -133,12 +146,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: JavaScript',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.8',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
-        'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Topic :: Education',
         'Topic :: Internet :: WWW/HTTP',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,9 @@
 [tox]
-envlist = csslint,eslint,pycodestyle,pylint,py38-django{22,30,31,32}, translations_validate
+envlist = csslint,eslint,pycodestyle,pylint,py38-django{32}, translations_validate
 
 [testenv]
 usedevelop = True
 deps = 
-    django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4.0
     -rrequirements/test.txt
 commands = 


### PR DESCRIPTION
### Description 
- Latest Python dependencies now fail tests with `Django 2.2`. 
- Removed tests for `Django<3.2.0` in the CI
- Bumped the package version to `3.0.0`
- Refactored the version number placement to follow standard convention across bom-squad's owned repos.

## TODO
- [ ] Publish a new GitHub Release and deploy bumped version on PyPI.