### PR TITLE
Remove xblockutils package

### DIFF
--- a/freetextresponse/__init__.py
+++ b/freetextresponse/__init__.py
@@ -4,4 +4,4 @@ Instructors can specify a list of phrases, of which one must be
 present in order for the student to receive credit.
 """
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"

--- a/freetextresponse/views.py
+++ b/freetextresponse/views.py
@@ -4,8 +4,13 @@ Handle view logic for the XBlock
 from six import text_type
 from xblock.core import XBlock
 from xblock.validation import ValidationMessage
-from xblockutils.resources import ResourceLoader
-from xblockutils.studio_editable import StudioEditableXBlockMixin
+try:
+    from xblock.utils.resources import ResourceLoader
+    from xblock.utils.studio_editable import StudioEditableXBlockMixin
+except ModuleNotFoundError:
+    # For backward compatibility with releases older than Quince.
+    from xblockutils.resources import ResourceLoader
+    from xblockutils.studio_editable import StudioEditableXBlockMixin
 
 from .mixins.dates import EnforceDueDates
 from .mixins.fragment import XBlockFragmentBuilderMixin

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,4 +4,3 @@
 Django
 six
 XBlock
-xblock-utils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,81 +8,44 @@ appdirs==1.4.4
     # via fs
 asgiref==3.7.2
     # via django
-boto3==1.28.68
-    # via fs-s3fs
-botocore==1.31.68
-    # via
-    #   boto3
-    #   s3transfer
 django==3.2.22
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-    #   openedx-django-pyfs
 fs==2.4.16
-    # via
-    #   fs-s3fs
-    #   openedx-django-pyfs
-    #   xblock
-fs-s3fs==1.1.1
-    # via openedx-django-pyfs
-jmespath==1.0.1
-    # via
-    #   boto3
-    #   botocore
-lazy==1.6
     # via xblock
 lxml==4.9.3
     # via xblock
 mako==1.2.4
-    # via
-    #   xblock
-    #   xblock-utils
+    # via xblock
 markupsafe==2.1.3
     # via
     #   mako
     #   xblock
-openedx-django-pyfs==3.4.0
-    # via xblock
 python-dateutil==2.8.2
-    # via
-    #   botocore
-    #   xblock
+    # via xblock
 pytz==2023.3.post1
     # via
     #   django
     #   xblock
 pyyaml==6.0.1
     # via xblock
-s3transfer==0.7.0
-    # via boto3
 simplejson==3.19.2
-    # via
-    #   xblock
-    #   xblock-utils
+    # via xblock
 six==1.16.0
     # via
     #   -r requirements/base.in
     #   fs
-    #   fs-s3fs
     #   python-dateutil
 sqlparse==0.4.4
     # via django
 typing-extensions==4.8.0
     # via asgiref
-urllib3==1.26.18
-    # via botocore
 web-fragments==2.1.0
-    # via
-    #   xblock
-    #   xblock-utils
+    # via xblock
 webob==1.8.7
     # via xblock
-xblock[django]==1.8.1
-    # via
-    #   -r requirements/base.in
-    #   xblock-utils
-xblock-utils==4.0.0
+xblock==1.8.1
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -18,7 +18,7 @@ distlib==0.3.7
     #   virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.12.4
+filelock==3.13.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -57,7 +57,7 @@ tox==3.28.0
     #   -r requirements/tox.txt
 urllib3==2.0.7
     # via requests
-virtualenv==20.24.5
+virtualenv==20.24.6
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-wheel==0.41.2
+wheel==0.41.3
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -21,7 +21,7 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.2
+wheel==0.41.3
     # via pip-tools
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -24,14 +24,12 @@ binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-boto3==1.28.68
+boto3==1.28.73
     # via
-    #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.31.68
+botocore==1.31.73
     # via
-    #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
@@ -67,7 +65,6 @@ django==3.2.22
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django-pyfs
-    #   openedx-django-pyfs
     #   xblock-sdk
 django-pyfs==3.2.0
     # via -r requirements/test.txt
@@ -79,14 +76,11 @@ fs==2.4.16
     #   -r requirements/test.txt
     #   django-pyfs
     #   fs-s3fs
-    #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
-    #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django-pyfs
-    #   openedx-django-pyfs
     #   xblock-sdk
 idna==3.4
     # via
@@ -100,15 +94,11 @@ jinja2==3.1.2
     #   cookiecutter
 jmespath==1.0.1
     # via
-    #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   boto3
     #   botocore
 lazy==1.6
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/test.txt
-    #   xblock
+    # via -r requirements/test.txt
 lxml==4.9.3
     # via
     #   -r requirements/base.txt
@@ -120,7 +110,6 @@ mako==1.2.4
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   xblock
-    #   xblock-utils
 markdown-it-py==3.0.0
     # via
     #   -r requirements/test.txt
@@ -140,11 +129,6 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.1.0
     # via -r requirements/test.txt
-openedx-django-pyfs==3.4.0
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/test.txt
-    #   xblock
 pbr==5.11.1
     # via
     #   -r requirements/test.txt
@@ -201,7 +185,6 @@ rich==13.6.0
     #   cookiecutter
 s3transfer==0.7.0
     # via
-    #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   boto3
 simplejson==3.19.2
@@ -210,7 +193,6 @@ simplejson==3.19.2
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-    #   xblock-utils
 six==1.16.0
     # via
     #   -r requirements/base.txt
@@ -250,7 +232,6 @@ typing-extensions==4.8.0
     #   rich
 urllib3==1.26.18
     # via
-    #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   botocore
     #   requests
@@ -260,26 +241,19 @@ web-fragments==2.1.0
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-    #   xblock-utils
 webob==1.8.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   xblock
     #   xblock-sdk
-xblock[django]==1.8.1
+xblock==1.8.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-    #   xblock
     #   xblock-sdk
-    #   xblock-utils
 xblock-sdk==0.7.0
     # via -r requirements/test.txt
-xblock-utils==4.0.0
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -8,4 +8,3 @@ edx-opaque-keys
 lazy
 mock
 xblock-sdk
-xblock-utils

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,9 +12,9 @@ asgiref==3.7.2
     # via django
 binaryornot==0.4.4
     # via cookiecutter
-boto3==1.28.68
+boto3==1.28.73
     # via fs-s3fs
-botocore==1.31.68
+botocore==1.31.73
     # via
     #   boto3
     #   s3transfer
@@ -35,7 +35,6 @@ ddt==1.6.0
     # via
     #   -c requirements/common_constraints.txt
     #   django-pyfs
-    #   openedx-django-pyfs
     #   xblock-sdk
 django-pyfs==3.2.0
     # via -r requirements/test.in
@@ -45,12 +44,10 @@ fs==2.4.16
     # via
     #   django-pyfs
     #   fs-s3fs
-    #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
     #   django-pyfs
-    #   openedx-django-pyfs
     #   xblock-sdk
 idna==3.4
     # via requests
@@ -61,17 +58,13 @@ jmespath==1.0.1
     #   boto3
     #   botocore
 lazy==1.6
-    # via
-    #   -r requirements/test.in
-    #   xblock
+    # via -r requirements/test.in
 lxml==4.9.3
     # via
     #   xblock
     #   xblock-sdk
 mako==1.2.4
-    # via
-    #   xblock
-    #   xblock-utils
+    # via xblock
 markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.3
@@ -83,8 +76,6 @@ mdurl==0.1.2
     # via markdown-it-py
 mock==5.1.0
     # via -r requirements/test.in
-openedx-django-pyfs==3.4.0
-    # via xblock
 pbr==5.11.1
     # via stevedore
 pygments==2.16.1
@@ -120,7 +111,6 @@ simplejson==3.19.2
     # via
     #   xblock
     #   xblock-sdk
-    #   xblock-utils
 six==1.16.0
     # via
     #   fs
@@ -147,18 +137,13 @@ web-fragments==2.1.0
     # via
     #   xblock
     #   xblock-sdk
-    #   xblock-utils
 webob==1.8.7
     # via
     #   xblock
     #   xblock-sdk
-xblock[django]==1.8.1
-    # via
-    #   xblock-sdk
-    #   xblock-utils
+xblock==1.8.1
+    # via xblock-sdk
 xblock-sdk==0.7.0
-    # via -r requirements/test.in
-xblock-utils==4.0.0
     # via -r requirements/test.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -6,7 +6,7 @@
 #
 distlib==0.3.7
     # via virtualenv
-filelock==3.12.4
+filelock==3.13.0
     # via
     #   tox
     #   virtualenv
@@ -26,5 +26,5 @@ tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/tox.in
-virtualenv==20.24.5
+virtualenv==20.24.6
     # via tox


### PR DESCRIPTION
ticket: https://github.com/openedx/xblock-free-text-response/issues/134

# Overview
What do we need to know about this change?

# Screenshot after PR implementation
<img width="1266" alt="image" src="https://github.com/openedx/xblock-free-text-response/assets/25842457/13bb6a51-9976-45e3-a88b-0cfa284a0a98">


# Test Instructions
[No special testing is required for it]

Checkout the branch
Install the xblock
Test on browser

# TODO
- [x] Compile static assets
- [x] Lint all files
- [x] Pass all tests
- [x] Bump the version number in `setup.py`
- [x] Attach screenshots?
- [x] Code Reviewer 1:
- [x] Code Reviewer 2:
- [ ] Submit PR against `edx-platform` to bump the version
- [ ] Upload to PyPi
