### PR TITLE
fix: The XBlock should work even when max_attempts is null

### DIFF
--- a/freetextresponse/__init__.py
+++ b/freetextresponse/__init__.py
@@ -4,4 +4,4 @@ Instructors can specify a list of phrases, of which one must be
 present in order for the student to receive credit.
 """
 
-__version__ = "5.0.1"
+__version__ = "5.0.2"

--- a/freetextresponse/tests/submitdisplay_class.json
+++ b/freetextresponse/tests/submitdisplay_class.json
@@ -1,7 +1,12 @@
 {
+    "empty_null_max": {
+        "max_attempts": null,
+        "count_attempts": 1, 
+        "result": ""
+    },
     "empty_zero_max": {
         "max_attempts": 0,
-        "count_attempts": 1, 
+        "count_attempts": 1,
         "result": ""
     },
     "empty_under_max": {

--- a/freetextresponse/tests/validate_field_data.json
+++ b/freetextresponse/tests/validate_field_data.json
@@ -1,5 +1,5 @@
 {
-    "weight_attemps_negative": {
+    "weight_attempts_negative": {
         "weight": -1,
         "max_attempts": 1,
         "max_word_count": 1,
@@ -7,7 +7,7 @@
         "submitted_message": "s",
         "result": "Weight Attempts cannot be negative"
     },
-    "max_attemps_negative": {
+    "max_attempts_negative": {
         "weight": 0,
         "max_attempts": -1,
         "max_word_count": 1,
@@ -34,6 +34,14 @@
     "submission_message_blank": {
         "weight": 0,
         "max_attempts": 1,
+        "max_word_count": 3,
+        "min_word_count": 2,
+        "submitted_message": "",
+        "result": "Submission Received Message cannot be blank"
+    },
+    "submission_message_blank_null_max_attempts": {
+        "weight": 0,
+        "max_attempts": null,
         "max_word_count": 3,
         "min_word_count": 2,
         "submitted_message": "",

--- a/freetextresponse/views.py
+++ b/freetextresponse/views.py
@@ -7,7 +7,7 @@ from xblock.validation import ValidationMessage
 try:
     from xblock.utils.resources import ResourceLoader
     from xblock.utils.studio_editable import StudioEditableXBlockMixin
-except ModuleNotFoundError:
+except ModuleNotFoundError:  # pragma: no cover
     # For backward compatibility with releases older than Quince.
     from xblockutils.resources import ResourceLoader
     from xblockutils.studio_editable import StudioEditableXBlockMixin
@@ -74,7 +74,7 @@ class FreeTextResponseViewMixin(
         Returns the css class for the submit button
         """
         result = ''
-        if self.max_attempts > 0 and self.count_attempts >= self.max_attempts:
+        if self.max_attempts and 0 < self.max_attempts <= self.count_attempts:
             result = 'nodisplay'
         return result
 
@@ -142,7 +142,7 @@ class FreeTextResponseViewMixin(
         they have used if applicable
         """
         result = ''
-        if self.max_attempts > 0:
+        if self.max_attempts and self.max_attempts > 0:
             result = self.ngettext(
                 'You have used {count_attempts} of {max_attempts} submission',
                 'You have used {count_attempts} of {max_attempts} submissions',
@@ -206,7 +206,7 @@ class FreeTextResponseViewMixin(
         Processes the user's submission
         """
         # Fails if the UI submit/save buttons were shut
-        # down on the previous sumbisson
+        # down on the previous submission
         if self._can_submit():
             self.student_answer = data['student_answer']
             # Counting the attempts and publishing a score
@@ -239,8 +239,8 @@ class FreeTextResponseViewMixin(
         Processes the user's save
         """
         # Fails if the UI submit/save buttons were shut
-        # down on the previous sumbisson
-        if self.max_attempts == 0 or self.count_attempts < self.max_attempts:
+        # down on the previous submission
+        if not self.max_attempts or self.count_attempts < self.max_attempts:
             self.student_answer = data['student_answer']
         result = {
             'status': 'success',
@@ -295,7 +295,7 @@ class FreeTextResponseViewMixin(
         """
         if self.is_past_due():
             return False
-        if self.max_attempts == 0:
+        if not self.max_attempts:
             return True
         if self.count_attempts < self.max_attempts:
             return True
@@ -321,7 +321,7 @@ class FreeTextResponseViewMixin(
                 'Weight Attempts cannot be negative'
             )
             validation.add(msg)
-        if data.max_attempts < 0:
+        if data.max_attempts and data.max_attempts < 0:
             msg = self._generate_validation_message(
                 'Maximum Attempts cannot be negative'
             )


### PR DESCRIPTION
# Overview

This change allows the XBlock to continue working in cases where max_attempts is set to null. Currently Studio and LMS will throw an error in such a case due to a number of places where max_attempts is compared to count_attempts without testing for None first.

# Test Instructions
- Set up this XBlock in a course
- Set the max_attempts in course advanced setting to 1, save, and then set it to null and save
- Test that the XBlock is working

# TODO
- [ ] Compile static assets
- [ ] Lint all files
- [x] Pass all tests
- [x] Bump the version number in `setup.py`
- [ ] Attach screenshots?
- [ ] Code Reviewer 1:
- [ ] Code Reviewer 2:
- [ ] Submit PR against `edx-platform` to bump the version
- [ ] Upload to PyPi
