### PR TITLE
Feat: Add django52 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version:
         - '3.11'
         - '3.12'
-        toxenv: [django42, quality, csslint, eslint, translations_validate]
+        toxenv: [django42, django52, quality, csslint, eslint, translations_validate]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 5.1.0
+* Added django52 support.
+
 ## Version 4.1.0
 * Added python 3.11 support. Dropped django32 support.
 

--- a/freetextresponse/__init__.py
+++ b/freetextresponse/__init__.py
@@ -4,4 +4,4 @@ Instructors can specify a list of phrases, of which one must be
 present in order for the student to receive credit.
 """
 
-__version__ = "5.0.2"
+__version__ = "5.1.0"

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
         'Topic :: Education',
         'Topic :: Internet :: WWW/HTTP',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = csslint,eslint,pycodestyle,pylint,py{311,312}-django{42}, translations_validate
+envlist = csslint,eslint,pycodestyle,pylint,py{311,312}-django{42,52}, translations_validate
 
 [testenv]
 usedevelop = True
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -rrequirements/test.txt
 commands =
     coverage run manage.py test freetextresponse.tests


### PR DESCRIPTION
Resolves [Add Django 5.2 support to xblock-free-text-response #228](https://github.com/openedx/xblock-free-text-response/issues/228) 

## Add Django 5.2 Support
This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

### Changes Made:
- Update ci and tox files
- Ran django-upgrade to apply necessary syntax updates for Django 5.2.
- Run tests using tox command and resolved the warning
- Ensured all modifications remain backward-compatible with Django 4.2.

### django-upgrade usage:
`git ls-files -z -- '*.py' | xargs -0r django-upgrade --target-version 5.2`
